### PR TITLE
Remove primer from codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @github/web-systems-reviewers @github/primer-reviewers
+* @github/web-systems-reviewers


### PR DESCRIPTION
Given web systems owns https://github.com/github/browser-support, it makes sense for us to be the main owners of this repo as well. I don't expect we'll make changes often (or ever) since the support list is relative, so we're going to drop down to just Web Systems as owners.