### PR TITLE
Add GitHub Actions workflow for NPM publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,29 @@
+name: Publish
+
+on:
+  release:
+    types: [created]
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish-npm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org/
+          cache: npm
+      - run: npm ci
+      - run: npx playwright install chromium
+      - run: npm test
+      - run: |
+          echo "Publishing $TAG_NAME"
+          npm version ${TAG_NAME} --git-tag-version=false
+        env:
+          TAG_NAME: ${{github.event.release.tag_name}}
+      - run: npm publish --provenance

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,8 +17,7 @@ jobs:
         with:
           node-version: 24
           registry-url: https://registry.npmjs.org/
-          cache: npm
-      - run: npm ci
+      - run: npm install
       - run: npx playwright install chromium
       - run: npm test
       - run: |


### PR DESCRIPTION
Create oidc publishing. I noticed this didn't even have a workflow...not sure if we need this, but figured we'd do it:

https://www.npmjs.com/package/@github/browserslist-config